### PR TITLE
Fix: imgur upload not work when album is empty

### DIFF
--- a/src/imgur.js
+++ b/src/imgur.js
@@ -100,7 +100,7 @@ async function GetAlbumArt(image_key, GetImageFn) {
 
         try {
             const { images } = album.data;
-            const art = images.find((image) => image.title == image_key);
+            const art = images?.find((image) => image.title == image_key);
 
             // Art doesn't exist, so upload it.
             let link = '';


### PR DESCRIPTION
Fixed an issue imgur upload won't work when the set album is empty.

the `images` var will be `null` when the album is empty.

result json of `GetAlbum` when it's empty

```js
{
  success: true,
  data: { images: null }
}
```

`data.images` is null. So, 

```js
const { images } = album.data; // it's null
const art = images.find((image) => image.title == image_key); // Cannot read properties of null (reading 'find')
```


