### PR TITLE
Fix payload when album name is a single character

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -235,7 +235,7 @@ async function SongChanged(core, data) {
         smallImageKey: DEFAULT_IMAGE,
         smallImageText: `Listening at: ${data.display_name}`,
         largeImageKey: PreviousAlbumArt.imageUrl,
-        largeImageText: (album)? album : `Listening at: ${data.display_name}`,
+        largeImageText: (album)? formatSongLine(album) : `Listening at: ${data.display_name}`,
     };
     Discord.Self().user?.setActivity(activity);
 


### PR DESCRIPTION
Seems like this has happened in a few places before, but now in the album `large_text` value, albums with single character names throw with:

```
INVALID_PAYLOAD: child "activity" fails because [child "assets" fails because [child "large_text" fails because ["large_text" length must be at least 2 characters long]]]
```

This just uses `formatSongLine` to add padding and fix that.

<img width="283" alt="image" src="https://github.com/user-attachments/assets/e1c61627-043f-47e3-8cfe-5a29affd0d4a" />
